### PR TITLE
updating the postgresql-client version

### DIFF
--- a/latest/Dockerfile
+++ b/latest/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update
 
 # Installing the packages needed to run Nightmare
 RUN apt-get install -y \
-  postgresql-client-9.4 \
+  postgresql-client-9.6 \
   xvfb \
   x11-xkb-utils \
   xfonts-100dpi \


### PR DESCRIPTION
The postgresql-client v9.4 was obsolete. Upading it to supported version 9.6